### PR TITLE
pdf format fix and groups page bug fix

### DIFF
--- a/client/src/components/arrangementIndexPage/ArrangementShow.js
+++ b/client/src/components/arrangementIndexPage/ArrangementShow.js
@@ -49,6 +49,8 @@ const ArrangementShow = (props) => {
       setArrangements(body.classSection.arrangements);
       if (body.classSection.arrangements.length > 0) {
         setFeaturedArrangement(body.classSection.arrangements[0]);
+      } else {
+        setFeaturedArrangement({ groups: [] });
       }
     } catch (error) {
       console.error(error);

--- a/client/src/components/pdf/PrintFriendlyPdf.js
+++ b/client/src/components/pdf/PrintFriendlyPdf.js
@@ -3,9 +3,10 @@ import { Page, Text, View, Document, StyleSheet } from "@react-pdf/renderer";
 
 const styles = StyleSheet.create({
   page: {
-    flexDirection: "row",
-    flexWrap: "wrap",
     margin: 50,
+  },
+  heading: {
+    textAlign: "center",
   },
   header: {
     textAlign: "center",
@@ -23,7 +24,8 @@ const styles = StyleSheet.create({
     fontSize: 12,
     padding: 10,
     border: 1,
-    marginLeft: 40,
+    textAlign: "left",
+    maxWidth: "83%",
   },
   groupsGrid: {
     flexDirection: "row",
@@ -76,7 +78,7 @@ const PrintFriendlyPdf = ({ arrangement, classSectionName, studentView }) => {
   return (
     <Document>
       <Page size="A4" style={styles.page}>
-        <View>
+        <View style={styles.heading}>
           <Text style={styles.header}>{classSectionName}</Text>
           <Text style={styles.header}>{arrangement.name}</Text>
           {!studentView ? arrangementDetails : undefined}


### PR DESCRIPTION
- fixed arrangement page bug where an arrangement was still on screen when switch to a class that did not have any groups created yet.
- updated pdf format so that when only one group is listed the text does not move up to the header row